### PR TITLE
feat: blockHeightMiddleware

### DIFF
--- a/server/api/server.go
+++ b/server/api/server.go
@@ -91,7 +91,6 @@ func blockHeightMiddleware(next http.Handler) http.Handler {
 		heightStr := r.FormValue("height")
 		if heightStr != "" {
 			height, err := strconv.ParseInt(heightStr, 10, 64)
-
 			if err != nil {
 				writeErrorResponse(w, http.StatusBadRequest, "syntax error")
 				return

--- a/server/api/server.go
+++ b/server/api/server.go
@@ -85,8 +85,8 @@ func New(clientCtx client.Context, logger log.Logger) *Server {
 	}
 }
 
-// heightMiddleware parses height query parameter and sets GRPCBlockHeightHeader
-func heightMiddleware(next http.Handler) http.Handler {
+// blockHeightMiddleware parses height query parameter and sets GRPCBlockHeightHeader
+func blockHeightMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		heightStr := r.FormValue("height")
 		if heightStr != "" {
@@ -132,7 +132,7 @@ func (s *Server) Start(cfg config.Config) error {
 
 	s.registerGRPCGatewayRoutes()
 	s.listener = listener
-	h := heightMiddleware(s.Router)
+	h := blockHeightMiddleware(s.Router)
 
 	s.mtx.Unlock()
 

--- a/x/bank/client/testutil/grpc.go
+++ b/x/bank/client/testutil/grpc.go
@@ -63,17 +63,17 @@ func (s *IntegrationTestSuite) TestTotalSupplyGRPCHandler() {
 				Amount: sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens.Add(sdk.NewInt(20))),
 			},
 		},
-		{
-			"Query params shouldn't be considered as height",
-			fmt.Sprintf("%s/cosmos/bank/v1beta1/supply/by_denom?denom=%s&height=2", baseURL, s.cfg.BondDenom),
-			map[string]string{
-				grpctypes.GRPCBlockHeightHeader: "1",
-			},
-			&types.QuerySupplyOfResponse{},
-			&types.QuerySupplyOfResponse{
-				Amount: sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens.Add(sdk.NewInt(10))),
-			},
-		},
+		// {
+		// 	"Query params shouldn't be considered as height",
+		// 	fmt.Sprintf("%s/cosmos/bank/v1beta1/supply/by_denom?denom=%s&height=2", baseURL, s.cfg.BondDenom),
+		// 	map[string]string{
+		// 		grpctypes.GRPCBlockHeightHeader: "1",
+		// 	},
+		// 	&types.QuerySupplyOfResponse{},
+		// 	&types.QuerySupplyOfResponse{
+		// 		Amount: sdk.NewCoin(s.cfg.BondDenom, s.cfg.StakingTokens.Add(sdk.NewInt(10))),
+		// 	},
+		// },
 		{
 			"GRPC total supply of a bogus denom",
 			fmt.Sprintf("%s/cosmos/bank/v1beta1/supply/by_denom?denom=foobar", baseURL),


### PR DESCRIPTION
## Description
Due to the discontinuation of legacy rest support in CosmosSDK v0.46.x, it is no longer possible to retrieve the state of a specific height simply by inserting the height as a query parameter. Instead, this functionality can be performed through a header called `x-cosmos-block-height`.

This PR adds support for URL query parameters for the convenience of existing L2 applications (e.g. FCD) and general users.

Fixes: [core #332](https://github.com/classic-terra/core/issues/332)