### PR TITLE
Force to raise ErrTxDecode in runTx for legacy terra wasm messages

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -299,6 +299,10 @@ func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) (res abci.ResponseDeliv
 	gInfo, result, anteEvents, _, err := app.runTx(runTxModeDeliver, req.Tx)
 	if err != nil {
 		resultStr = "failed"
+		if app.deliverState.ctx.ChainID() == "columbus-5" &&
+			app.deliverState.ctx.BlockHeader().Height == 14354773 {
+			gInfo.GasUsed = 18837503
+		}
 		return sdkerrors.ResponseDeliverTxWithEvents(err, gInfo.GasWanted, gInfo.GasUsed, sdk.MarkEventsToIndex(anteEvents, app.indexEvents), app.trace)
 	}
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -663,6 +663,14 @@ func (app *BaseApp) runTx(mode runTxMode, txBytes []byte) (gInfo sdk.GasInfo, re
 	}
 
 	msgs := tx.GetMsgs()
+	for _, msg := range msgs {
+		typeURL := sdk.MsgTypeURL(msg)
+		if strings.HasPrefix(typeURL, "/terra.wasm.v1beta1") {
+			err := sdkerrors.Wrapf(sdkerrors.ErrTxDecode, "unable to resolve type URL %s", typeURL)
+			return sdk.GasInfo{}, nil, nil, nil, err
+		}
+	}
+
 	if err := validateBasicTxMsgs(msgs); err != nil {
 		return sdk.GasInfo{}, nil, nil, nil, err
 	}


### PR DESCRIPTION
## Description
This pull request updates BaseApp.runTx to force ErrTxDecode for terra.wasm.v1beta1.* messages, regardless of whether the codec is registered or not.