### PR TITLE
set iavlDisablefastNodeDefault to true

### DIFF
--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -35,7 +35,7 @@ const (
 	commitInfoKeyFmt = "s/%d" // s/<version>
 )
 
-const iavlDisablefastNodeDefault = false
+const iavlDisablefastNodeDefault = true
 
 // Store is composed of many CommitStores. Name contrasts with
 // cacheMultiStore which is used for branching other MultiStores. It implements


### PR DESCRIPTION
## Description
In the past, the value of `iavlDisableFastNodeDefault` in Terra Classic was set to true, so the IAVL FastNode feature has never been used in Terra Classic. If this value is changed to false, migration will be forced to occur at every node startup.

When testing the migration of Columbus-5, it took approximately 50 minutes on a machine with a 3.6Ghz Intel Core i9 and 128GB of memory.

In addition, the recently discovered bug in IAVL (https://github.com/cosmos/iavl/pull/805) only occurs in nodes using fast nodes.

This PR changes `iavlDisableFastNodeDefault = true`